### PR TITLE
update to use non deprecated pluginlib macro

### DIFF
--- a/src/heightmap_nodelet.cpp
+++ b/src/heightmap_nodelet.cpp
@@ -38,8 +38,7 @@ namespace velodyne_height_map {
 
 }; // namespace velodyne_height_map
 
-// Register this plugin with pluginlib.  Names must match height_map_nodelet.xml.
+// Register this plugin with pluginlib.  Names must match nodelets.xml.
 //
-// parameters: package, class name, class type, base class type
-PLUGINLIB_DECLARE_CLASS(velodyne_height_map, HeightMapNodelet,
-                        velodyne_height_map::HeightMapNodelet, nodelet::Nodelet);
+// parameters: class type, base class type
+PLUGINLIB_EXPORT_CLASS(velodyne_height_map::HeightMapNodelet, nodelet::Nodelet)


### PR DESCRIPTION
These macros, deprecated for now 8 years, will be removed in the next ROS release (ROS Melodic)

This change will allow the code to keep compiling on future ROS versions